### PR TITLE
4.0.1

### DIFF
--- a/SpotiFLAC/core/solver.py
+++ b/SpotiFLAC/core/solver.py
@@ -690,8 +690,13 @@ def _ensure_xvfb() -> None:
     with _xvfb_lock:
         if _xvfb_started or _display_is_live(os.environ.get("DISPLAY", "")):
             return
-        _start_xvfb_if_needed()
-        _xvfb_started = True
+        # Latched only on a display that actually came up. Xvfb dying on the
+        # spot — a stale /tmp/.X99-lock is the usual reason — is reported as
+        # None, and recording that as "started" would make every later call
+        # return early: the process would run on with no display and never
+        # try again. Left false, the next solve gets another attempt.
+        if _start_xvfb_if_needed() is not None:
+            _xvfb_started = True
 
 
 def build_chromium_options(*, hidden: bool = True) -> tuple[ChromiumOptions, str]:

--- a/SpotiFLAC/core/solver.py
+++ b/SpotiFLAC/core/solver.py
@@ -9,6 +9,7 @@ import platform
 import random
 import shutil
 import signal
+import socket
 import subprocess
 import tempfile
 import threading
@@ -581,11 +582,65 @@ def _get_profile_dir() -> str:
     return tempfile.mkdtemp(prefix="ts_profile_", dir=base)
 
 
+#: How long to wait for a freshly started Xvfb to accept connections.
+_XVFB_READY_TIMEOUT_SECONDS = 10.0
+
+#: Where a local X server puts its socket. A constant so the probe below can
+#: be pointed somewhere writable under test.
+_X11_SOCKET_DIR = "/tmp/.X11-unix"  # noqa: S108 — the path X11 itself defines
+
+
+def _display_is_live(display: str) -> bool:
+    """Whether an X server is actually answering on *display*.
+
+    A set ``DISPLAY`` is not a running X server, and the gap between the two
+    is exactly how a ``--web`` container ends up unable to solve a challenge:
+    the image sets ``DISPLAY=:99`` for every mode, while its entrypoint only
+    starts Xvfb on the GUI path. The variable was set, so the bootstrap below
+    concluded there was a display and returned — and Chromium then spent its
+    whole 45-second start timeout trying to reach one nobody had started,
+    failing with ``FailedToStartBrowser`` while reporting ``binary_exists=True``
+    and ``display=:99``, which is a genuinely confusing pair of facts.
+
+    Only *local* displays (``:99``, ``:0.0``, ``unix:0``) are probed, over the
+    socket the server listens on. A ``host:0`` or an SSH-forwarded
+    ``localhost:10.0`` belongs to somebody else's X server and is taken at its
+    word rather than second-guessed — or worse, stomped on by starting Xvfb
+    over the top of it.
+    """
+    display = (display or "").strip()
+    if not display:
+        return False
+    host, separator, screen = display.rpartition(":")
+    if not separator or host not in {"", "unix"}:
+        return True
+    number = screen.split(".", 1)[0]
+    if not number.isdigit():
+        return True
+    path = os.path.join(_X11_SOCKET_DIR, f"X{number}")
+    # Both the filesystem socket and — Linux only — the abstract one of the
+    # same name. A server that listens on just the abstract address would
+    # otherwise read as dead, and Xvfb would be started on top of a display
+    # that was working.
+    candidates = [path]
+    if platform.system() == "Linux":
+        candidates.append("\0" + path)
+    for candidate in candidates:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                probe.settimeout(0.5)
+                probe.connect(candidate)
+        except OSError:
+            continue
+        return True
+    return False
+
+
 def _start_xvfb_if_needed() -> subprocess.Popen | None:
     """On Linux headless servers, start a virtual display so Chrome can run."""
     if platform.system() != "Linux":
         return None
-    if os.environ.get("DISPLAY"):
+    if _display_is_live(os.environ.get("DISPLAY", "")):
         return None
     proc = subprocess.Popen(
         ["Xvfb", ":99", "-screen", "0", "1280x900x24"],
@@ -593,7 +648,29 @@ def _start_xvfb_if_needed() -> subprocess.Popen | None:
         stderr=subprocess.DEVNULL,
     )
     os.environ["DISPLAY"] = ":99"
-    time.sleep(0.5)
+    # Polled rather than slept: Xvfb comes up in whatever time the machine
+    # takes, and a flat 0.5s was both wasteful on an idle box and too short on
+    # a loaded one — where Chromium raced it and failed exactly as if no
+    # display had been started at all.
+    deadline = time.monotonic() + _XVFB_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if _display_is_live(":99"):
+            logger.info("[solver] virtual display :99 is up")
+            return proc
+        if proc.poll() is not None:
+            logger.error(
+                "[solver] Xvfb exited immediately (code %s). A stale "
+                "/tmp/.X99-lock from a previous run will do this — remove it, "
+                "or start your own X server and point DISPLAY at it.",
+                proc.returncode,
+            )
+            return None
+        time.sleep(0.05)
+    logger.warning(
+        "[solver] Xvfb did not accept connections within %.0fs; launching the "
+        "browser anyway",
+        _XVFB_READY_TIMEOUT_SECONDS,
+    )
     return proc
 
 
@@ -606,10 +683,12 @@ def _ensure_xvfb() -> None:
     running. Idempotent and safe to call from multiple threads.
     """
     global _xvfb_started
-    if _xvfb_started or platform.system() != "Linux" or os.environ.get("DISPLAY"):
+    if _xvfb_started or platform.system() != "Linux":
+        return
+    if _display_is_live(os.environ.get("DISPLAY", "")):
         return
     with _xvfb_lock:
-        if _xvfb_started or os.environ.get("DISPLAY"):
+        if _xvfb_started or _display_is_live(os.environ.get("DISPLAY", "")):
             return
         _start_xvfb_if_needed()
         _xvfb_started = True

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,9 +2,19 @@
 set -e
 
 # ==============================================================================
-# [WEB MODE]: if --web is among the arguments, skip Xvfb/Fluxbox/VNC entirely —
-# the FastAPI/uvicorn server needs no virtual display. Map the app's own port
-# instead (default 8000), not 6080/5900 (those are for the old VNC-based GUI).
+# [WEB MODE]: if --web is among the arguments, skip Xvfb/Fluxbox/VNC here and
+# map the app's own port instead (default 8000), not 6080/5900 (those are for
+# the old VNC-based GUI).
+#
+# "Skip", not "never needs": uvicorn itself wants no display, but a download it
+# serves can still have to solve a Turnstile challenge, and core/solver.py
+# launches a real (non-headless) Chromium to do it. That browser needs an X
+# server, so the solver brings one up on demand — which is cheaper than an
+# Xvfb in every container that never goes near a challenge.
+#
+# Note the image sets DISPLAY=:99 for every mode (see the Dockerfile), so the
+# solver has to check whether anything is actually listening there rather than
+# trust the variable. It does; if you change either side, keep that true.
 #
 # Example:
 # docker run --rm -it \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "4.0.0"
+version = "4.0.1"
 description = "Fetch Spotify track metadata and retrieve matching lossless audio through configurable Tidal, Qobuz & Amazon Music provider backends."
 readme = "README.md"
 # 3.10, not 3.9: core/models.py declares PEP 604 unions (`str | None`) on

--- a/tests/test_solver_virtual_display.py
+++ b/tests/test_solver_virtual_display.py
@@ -21,6 +21,16 @@ import pytest
 from SpotiFLAC.core import solver
 
 
+# The probe reaches an X server over an AF_UNIX socket, which Windows has no
+# notion of — CPython does not even define socket.AF_UNIX there. The two tests
+# that stand a real socket up are POSIX-only; the rest of the file exercises
+# the parsing, which is platform-agnostic, and runs everywhere.
+needs_unix_sockets = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX"),
+    reason="no AF_UNIX on this platform, so no X11 socket to probe",
+)
+
+
 @pytest.fixture
 def x11_socket_dir(monkeypatch):
     """A stand-in for /tmp/.X11-unix the probe can be pointed at.
@@ -51,11 +61,13 @@ def test_an_unset_display_is_not_live() -> None:
     assert solver._display_is_live("   ") is False
 
 
+@needs_unix_sockets
 def test_a_local_display_with_nobody_listening_is_not_live(x11_socket_dir) -> None:
     """The Docker case: DISPLAY=:99, and no Xvfb behind it."""
     assert solver._display_is_live(":99") is False
 
 
+@needs_unix_sockets
 def test_a_display_someone_answers_on_is_live(x11_socket_dir) -> None:
     server = _listening(x11_socket_dir / "X7")
     try:

--- a/tests/test_solver_virtual_display.py
+++ b/tests/test_solver_virtual_display.py
@@ -115,3 +115,53 @@ def test_a_live_display_is_left_alone(monkeypatch) -> None:
     solver._ensure_xvfb()
 
     assert started == []
+
+
+def test_a_failed_xvfb_start_leaves_room_for_a_retry(monkeypatch) -> None:
+    """A display that never came up must not be recorded as started.
+
+    Xvfb exits on the spot when a stale /tmp/.X99-lock is lying around, and
+    the helper reports that by returning None. Latching the flag anyway left
+    the process without a display for the rest of its life, since every later
+    call returned at the first `if _xvfb_started`.
+    """
+    monkeypatch.setattr(solver.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(solver, "_xvfb_started", False)
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.setattr(solver, "_display_is_live", lambda display: False)
+
+    attempts: list[str] = []
+
+    def failed_start() -> None:
+        attempts.append("attempt")
+        return None
+
+    monkeypatch.setattr(solver, "_start_xvfb_if_needed", failed_start)
+
+    solver._ensure_xvfb()
+    assert solver._xvfb_started is False, "a display that never came up is not started"
+
+    solver._ensure_xvfb()
+    assert attempts == ["attempt", "attempt"], "the next call must try again"
+
+
+def test_a_successful_xvfb_start_is_only_done_once(monkeypatch) -> None:
+    """The other half: a display that did come up is not started twice."""
+    monkeypatch.setattr(solver.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(solver, "_xvfb_started", False)
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.setattr(solver, "_display_is_live", lambda display: False)
+
+    attempts: list[str] = []
+
+    def successful_start() -> object:
+        attempts.append("attempt")
+        return object()  # stands in for the Popen the real helper returns
+
+    monkeypatch.setattr(solver, "_start_xvfb_if_needed", successful_start)
+
+    solver._ensure_xvfb()
+    assert solver._xvfb_started is True
+
+    solver._ensure_xvfb()
+    assert attempts == ["attempt"], "a live display must not be started again"

--- a/tests/test_solver_virtual_display.py
+++ b/tests/test_solver_virtual_display.py
@@ -1,0 +1,106 @@
+"""A set DISPLAY is not a running X server.
+
+The `--web` container never started Xvfb — its entrypoint skips the display
+setup for web mode — while the image sets `DISPLAY=:99` for every mode. The
+bootstrap read the variable, concluded a display existed and returned, so
+every Turnstile solve spent Chromium's full 45s start timeout reaching for a
+display nobody had started, and reported `FailedToStartBrowser` next to
+`binary_exists=True`.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import socket
+import tempfile
+
+import pytest
+
+from SpotiFLAC.core import solver
+
+
+@pytest.fixture
+def x11_socket_dir(monkeypatch):
+    """A stand-in for /tmp/.X11-unix the probe can be pointed at.
+
+    Under /tmp rather than pytest's tmp_path: an AF_UNIX path is capped at
+    ~104 bytes and the usual tmp_path (/var/folders/... on macOS) blows
+    through it.
+    """
+    directory = pathlib.Path(tempfile.mkdtemp(prefix="x11-", dir="/tmp"))
+    monkeypatch.setattr(solver, "_X11_SOCKET_DIR", str(directory))
+    yield directory
+    shutil.rmtree(directory, ignore_errors=True)
+
+
+def _listening(path) -> socket.socket:
+    """An X server, as far as the probe is concerned: something that accepts."""
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(path))
+    # Backlog well over 1: the probe connects and never accepts, so a
+    # one-deep queue fills on the first call and the second probe of the same
+    # display is refused — a property of this stub, not of an X server.
+    server.listen(64)
+    return server
+
+
+def test_an_unset_display_is_not_live() -> None:
+    assert solver._display_is_live("") is False
+    assert solver._display_is_live("   ") is False
+
+
+def test_a_local_display_with_nobody_listening_is_not_live(x11_socket_dir) -> None:
+    """The Docker case: DISPLAY=:99, and no Xvfb behind it."""
+    assert solver._display_is_live(":99") is False
+
+
+def test_a_display_someone_answers_on_is_live(x11_socket_dir) -> None:
+    server = _listening(x11_socket_dir / "X7")
+    try:
+        assert solver._display_is_live(":7") is True
+        assert solver._display_is_live(":7.0") is True
+    finally:
+        server.close()
+
+
+def test_a_remote_display_is_taken_at_its_word() -> None:
+    """Not ours to probe, and definitely not ours to start Xvfb over."""
+    assert solver._display_is_live("somehost:0") is True
+    assert solver._display_is_live("localhost:10.0") is True
+
+
+def test_a_dead_display_starts_one_instead_of_returning(monkeypatch) -> None:
+    """The bug itself: DISPLAY set, nothing listening, no Xvfb started."""
+    monkeypatch.setattr(solver.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(solver, "_xvfb_started", False)
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.setattr(solver, "_display_is_live", lambda display: False)
+
+    started: list[str] = []
+    monkeypatch.setattr(
+        solver,
+        "_start_xvfb_if_needed",
+        lambda: started.append(os.environ.get("DISPLAY", "")),
+    )
+
+    solver._ensure_xvfb()
+
+    assert started == [":99"], "a dead DISPLAY must not pass for a live one"
+
+
+def test_a_live_display_is_left_alone(monkeypatch) -> None:
+    monkeypatch.setattr(solver.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(solver, "_xvfb_started", False)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(solver, "_display_is_live", lambda display: True)
+
+    started: list[str] = []
+    monkeypatch.setattr(
+        solver, "_start_xvfb_if_needed", lambda: started.append("started")
+    )
+
+    solver._ensure_xvfb()
+
+    assert started == []

--- a/tests/test_solver_virtual_display.py
+++ b/tests/test_solver_virtual_display.py
@@ -20,7 +20,6 @@ import pytest
 
 from SpotiFLAC.core import solver
 
-
 # The probe reaches an X server over an AF_UNIX socket, which Windows has no
 # notion of — CPython does not even define socket.AF_UNIX there. The two tests
 # that stand a real socket up are POSIX-only; the rest of the file exercises


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual display detection by verifying that the configured X server is actively responding.
  * Xvfb now starts only when needed and waits for the display to become ready, improving reliability for browser-based downloads and challenge handling.
  * Added clearer diagnostics when the virtual display exits unexpectedly or fails to start.
  * Failed Xvfb startups can be retried automatically.
  * Improved handling of local, remote, and forwarded display connections.

* **Chores**
  * Updated the application version to 4.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->