### PR TITLE
4.0.3

### DIFF
--- a/SpotiFLAC/tui/queue_view.py
+++ b/SpotiFLAC/tui/queue_view.py
@@ -38,6 +38,19 @@ _BADGE_CLASSES = (
 
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "skipped"})
 
+#: The row's own state classes for a status. One definition, because
+#: __init__ sets them and apply() has to be able to clear them again.
+_ROW_STATE_CLASSES = {
+    "failed": "failed",
+    "completed": "completed",
+    "downloading": "active",
+}
+
+
+def _row_state_classes(status: str) -> tuple[str, ...]:
+    css = _ROW_STATE_CLASSES.get(status)
+    return (css,) if css else ()
+
 
 class TrackRow(Horizontal):
     """One track: what it is, how far along, and how it ended.
@@ -49,7 +62,15 @@ class TrackRow(Horizontal):
     """
 
     def __init__(self, item: dict) -> None:
-        super().__init__(classes="track-row")
+        # State classes from the start, not from on_mount. mount() is
+        # asynchronous, so a row built without them paints at least one frame
+        # as though the track were still queued — and anything reading the
+        # row before on_mount has run sees the same wrong answer.
+        super().__init__(
+            classes=" ".join(
+                ("track-row", *_row_state_classes(str(item.get("status", ""))))
+            )
+        )
         self._item = item
         self._bar: ProgressBar | None = None
         self._label: Label | None = None
@@ -59,7 +80,10 @@ class TrackRow(Horizontal):
         # The badge is MovieBox's resolution chip, doing the same job: the
         # outcome, readable at a glance from colour and shape together, so
         # colour alone is never carrying it.
-        self._badge = Label("", classes="track-badge", markup=False)
+        # Rendered from the item for the same reason as the classes above:
+        # left as Label(""), the outcome is blank until on_mount fills it in.
+        text, css = status_badge(str(self._item.get("status", "")))
+        self._badge = Label(text, classes=f"track-badge {css}", markup=False)
         self._label = Label(self._title_for(self._item), classes="track-title")
         # `total` is not known until the first chunk arrives, and a bar with
         # no total renders as indeterminate — which is exactly the honest

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -109,9 +109,28 @@ services:
       TZ: "${TZ:-Europe/Rome}"
 
     volumes:
-      # Finished audio. Swap for a bind mount to your NAS share if you prefer,
-      # e.g. "/mnt/media/music:/app/downloads".
+      # Finished audio, mounted at BOTH paths that matter — one named volume,
+      # two mount points, same content.
+      #
+      # /app/downloads is what the image declares as its downloads VOLUME and
+      # what the CLI examples pass explicitly; without a mount here Docker
+      # invents an anonymous volume for it.
+      #
+      # ~/Music/SpotiFLAC is where --web actually writes: app.py sets
+      # download_dir from core.paths.default_download_dir(), and nothing on
+      # the web path ever overrides it. Left unmounted, every download lands
+      # in the container's writable layer and dies with the next recreate —
+      # which is what Watchtower does on every update.
+      #
+      # Changing it from the GUI instead is not an option: webapp.py's
+      # _is_path_safe confines the folder picker to $HOME and the current
+      # download_dir, so /app/downloads cannot be selected from there.
+      #
+      # For a NAS share, point both at the same host path, e.g.
+      #   - /mnt/media/music:/app/downloads
+      #   - /mnt/media/music:/home/spotiflac/Music/SpotiFLAC
       - spotiflac-downloads:/app/downloads
+      - spotiflac-downloads:/home/spotiflac/Music/SpotiFLAC
       # Everything durable *and* the cache: the database, installed
       # extensions, signed sessions, web users, trusted keys, settings — and
       # ~/.spotiflac/.cache, which is where the cache lives now. One volume

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "4.0.2"
+version = "4.0.3"
 description = "Fetch Spotify track metadata and retrieve matching lossless audio through configurable Tidal, Qobuz & Amazon Music provider backends."
 readme = "README.md"
 # 3.10, not 3.9: core/models.py declares PEP 604 unions (`str | None`) on


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue items now display their correct status and badge immediately, including failed, completed, and active states.
  - Web-mode downloads now persist across container recreation and remain accessible from the configured downloads location.

- **Documentation**
  - Added guidance for NAS bind mounts and web-mode download directory behavior.

- **Chores**
  - Updated the application version to 4.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->