### PR TITLE
4.1.2

### DIFF
--- a/SpotiFLAC/api_mixins/failed_tracks.py
+++ b/SpotiFLAC/api_mixins/failed_tracks.py
@@ -1,0 +1,58 @@
+"""api_mixins/failed_tracks.py — the queue panel's list of tracks still missing.
+
+See core/failed_tracks.py for how the list is kept. This mixin is only the
+adapter: read it, retry it, clear it. A retry goes through the same path as
+any other download (`_start_download_job`), so in --web mode it is written
+down first and survives a restart just like the download it is retrying.
+
+Multi-user mode needs nothing extra: each account has its own Api instance
+with its own `owner`, and the list is keyed by owner.
+"""
+
+from __future__ import annotations
+
+
+class FailedTracksMixin:
+    def get_failed_tracks(self) -> dict:
+        """Every track that failed and has not downloaded since. Never raises."""
+        from ..core import failed_tracks
+
+        tracks = failed_tracks.list_for(getattr(self, "owner", "") or "")
+        return {"tracks": tracks, "count": len(tracks)}
+
+    def retry_failed_tracks(
+        self, config: dict | None = None, keys: list[str] | None = None
+    ) -> dict:
+        """Downloads the listed failures again — all of them, or only `keys`.
+
+        One job per source collection (see failed_tracks.retry_groups). A row
+        stays in the list until its track actually downloads: a retry that
+        fails again only raises the attempt count, it does not lose the track.
+        """
+        from ..core import failed_tracks
+
+        groups = failed_tracks.retry_groups(getattr(self, "owner", "") or "", keys)
+        queued = 0
+        for source_url, tracks in groups:
+            self._start_download_job(
+                {
+                    "indices": list(range(len(tracks))),
+                    "tracks": tracks,
+                    "source_url": source_url,
+                    # A retry is always a hand-picked selection, never "the
+                    # whole collection": the collection is what already ran.
+                    "whole": False,
+                    "config": dict(config or {}),
+                }
+            )
+            queued += len(tracks)
+        if queued:
+            self.log(f"Retrying {queued} failed track(s)…", "info")
+        return {"queued": queued}
+
+    def clear_failed_tracks(self, keys: list[str] | None = None) -> dict:
+        """Drops failures from the list without retrying them."""
+        from ..core import failed_tracks
+
+        owner = getattr(self, "owner", "") or ""
+        return {"removed": failed_tracks.clear(owner, keys)}

--- a/SpotiFLAC/app.py
+++ b/SpotiFLAC/app.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from .api_mixins.csv_import import CsvImportMixin
 from .api_mixins.dedup import DedupMixin
 from .api_mixins.discovery import DiscoveryMixin
 from .api_mixins.extension_health import ExtensionHealthMixin
+from .api_mixins.failed_tracks import FailedTracksMixin
 from .api_mixins.local_tagging import LocalTaggingMixin
 from .api_mixins.search import SearchMixin
 from .api_mixins.stats import StatsMixin
@@ -173,6 +175,7 @@ class SpotiFLAC_API(
     ExtensionHealthMixin,
     CsvImportMixin,
     StatsMixin,
+    FailedTracksMixin,
 ):
     """pywebview/`--web` bridge — every method here (plus the two mixins
     above) becomes a callable the frontend invokes as `pywebview.api.<name>`
@@ -198,6 +201,15 @@ class SpotiFLAC_API(
         # Held for the whole of a download batch, so two of them never share
         # a process — see _await_download_slot().
         self._download_lock = threading.Lock()
+        # Set by webapp.py in --web mode: a persisted JobQueue that
+        # download_tracks() writes each batch into instead of starting a bare
+        # thread, so a restart resumes it (see run_download_job). None
+        # everywhere else, the desktop window included — nothing should start
+        # downloading by itself because the app was opened.
+        self._download_queue = None
+        # Tells this process's own download jobs from ones a queue restored
+        # from an earlier process — see run_download_job().
+        self._session_id = uuid.uuid4().hex
         # Optional callable set by webapp.py in web mode: fn(event_name, args_list).
         # Desktop (pywebview) mode never sets this and is completely unaffected.
         self._ws_broadcast = None
@@ -1279,11 +1291,95 @@ class SpotiFLAC_API(
     # ── Phase 2: Download ─────────────────────────────────────────────────────
 
     def download_tracks(self, selected_indices, config) -> None:
+        if self._download_queue is not None:
+            payload = self._download_job_payload(selected_indices, config)
+            if payload is not None:
+                self._submit_download_job(payload)
+                return
         threading.Thread(
             target=self._download_task,
             args=(selected_indices, config),
             daemon=True,
         ).start()
+
+    def _download_job_payload(self, selected_indices, config) -> dict | None:
+        """One download request, in a form that outlives the process.
+
+        The tracks themselves rather than their positions: `current_tracks`
+        is replaced by the next fetch and empty after a restart, so indices
+        alone would resume into nothing — or into another playlist. The
+        indices ride along only so the page that asked can close the right
+        rows when the batch ends. None when a selected track cannot be written
+        down; the batch then runs the old, unpersisted way rather than not at
+        all.
+        """
+        try:
+            indices = [int(i) for i in selected_indices]
+            tracks = [self.current_tracks[i].model_dump(mode="json") for i in indices]
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return None
+        return {
+            "indices": indices,
+            "tracks": tracks,
+            "source_url": self.current_url or "",
+            # Decided now, against the tracklist the user was looking at:
+            # after a restart there is no tracklist left to compare with.
+            "whole": sorted(indices) == list(range(len(self.current_tracks))),
+            "config": dict(config or {}),
+            "session": self._session_id,
+        }
+
+    def _start_download_job(self, payload: dict) -> None:
+        """Runs a self-contained download job: queued in --web mode, else now."""
+        if self._download_queue is not None:
+            self._submit_download_job(payload)
+            return
+        threading.Thread(
+            target=self.run_download_job, args=(payload,), daemon=True
+        ).start()
+
+    def _submit_download_job(self, payload: dict) -> None:
+        from .core.job_queue import QueueFullError
+
+        try:
+            self._download_queue.submit(self.owner, payload)
+        except QueueFullError as exc:
+            self.log(
+                f"{exc.pending} downloads are already waiting (limit {exc.limit}); "
+                "try again once some have finished.",
+                "error",
+            )
+
+    def run_download_job(self, payload: dict) -> dict:
+        """Runs one download job to the end, in the calling thread.
+
+        The persisted queue's handler (see webapp.py), which is why it
+        blocks: the job has to stay RUNNING until the batch is really over,
+        or a restart halfway through would find it DONE and drop the rest.
+        A job left over from an earlier process carries that process's
+        session id and finishes as a background download, since no open page
+        dispatched it (see app_background_download_finished in app.js).
+        """
+        from .core.models import TrackMetadata
+
+        indices = [int(i) for i in payload.get("indices") or []]
+        raw_tracks = payload.get("tracks") or []
+        if len(raw_tracks) != len(indices):
+            msg = "Malformed download job: tracks and indices do not match"
+            raise ValueError(msg)
+        tracks = {
+            i: TrackMetadata.model_validate(t)
+            for i, t in zip(indices, raw_tracks, strict=True)
+        }
+        self._download_task(
+            indices,
+            dict(payload.get("config") or {}),
+            tracks_by_index=tracks,
+            source_url=str(payload.get("source_url") or ""),
+            whole=bool(payload.get("whole")),
+            announce=payload.get("session") == self._session_id,
+        )
+        return {"tracks": len(indices)}
 
     def _await_download_slot(self, selected_indices) -> None:
         """Blocks until no other download batch is running.
@@ -1311,7 +1407,7 @@ class SpotiFLAC_API(
         )
         self._download_lock.acquire()
 
-    def _download_task(self, selected_indices, config) -> None:
+    def _download_task(self, selected_indices, config, **batch) -> None:
         """Runs one batch start to finish, never overlapping another one.
 
         The lock is taken and released here rather than around the body
@@ -1322,7 +1418,7 @@ class SpotiFLAC_API(
         """
         self._await_download_slot(selected_indices)
         try:
-            self._run_download_batch(selected_indices, config)
+            self._run_download_batch(selected_indices, config, **batch)
         finally:
             self._download_lock.release()
 
@@ -1369,7 +1465,24 @@ class SpotiFLAC_API(
             "debug",
         )
 
-    def _run_download_batch(self, selected_indices, config) -> None:
+    def _run_download_batch(
+        self,
+        selected_indices,
+        config,
+        *,
+        tracks_by_index: dict | None = None,
+        source_url: str | None = None,
+        whole: bool | None = None,
+        announce: bool = True,
+    ) -> None:
+        """One batch, start to finish.
+
+        The keyword arguments come from a persisted job (see
+        run_download_job), which carries its own tracks, source and
+        whole-collection decision; without them the batch reads the tracklist
+        on screen, as it always has. `announce=False` ends the batch with
+        app_background_download_finished instead of app_download_finished.
+        """
         self._download_active.set()
         from .client import _CleanConsoleFormatter
 
@@ -1496,7 +1609,8 @@ class SpotiFLAC_API(
                 self.log("Error: select at least one service.", "error")
                 return
 
-            collection_url = (self.current_url or "").strip()
+            source = self.current_url if source_url is None else source_url
+            collection_url = (source or "").strip()
             # A track list loaded from a CSV has no collection URL to stand
             # for it (see api_mixins/csv_import.py), so the whole-collection
             # shortcut only applies when there really is one.
@@ -1510,8 +1624,10 @@ class SpotiFLAC_API(
             # Every track exactly once, not merely as many indices as tracks:
             # [0, 0, 1] out of three is not the whole collection, and in --web
             # mode this list is an HTTP body.
-            whole_list = sorted(selected_indices) == list(
-                range(len(self.current_tracks))
+            whole_list = (
+                whole
+                if whole is not None
+                else sorted(selected_indices) == list(range(len(self.current_tracks)))
             )
             if from_a_link and whole_list:
                 urls_to_download = [collection_url]
@@ -1527,8 +1643,12 @@ class SpotiFLAC_API(
                 from .core.tracklist import track_url
 
                 for i in selected_indices:
-                    t = self.current_tracks[i]
-                    t_url = track_url(t, self.current_url)
+                    t = (
+                        tracks_by_index[i]
+                        if tracks_by_index is not None
+                        else self.current_tracks[i]
+                    )
+                    t_url = track_url(t, source)
                     if t_url:
                         urls_to_download.append(t_url)
                         if from_a_link and isinstance(t, TrackMetadata):
@@ -1586,6 +1706,12 @@ class SpotiFLAC_API(
             # dashboard would have shown an empty history to precisely the
             # people who never touch the CLI.
             log_hook = record_hook(self.owner)
+            # A track that fails stays listed, with what a retry needs, until
+            # it downloads (core/failed_tracks.py): the downloader's own list
+            # of failures ends with this call.
+            from .core import failed_tracks
+
+            failed_hook = failed_tracks.hook(self.owner, collection_url)
 
             # ONE call, not one per URL. client.SpotiFLAC() is a one-shot
             # entry point: it opens an event loop, an httpx pool, an
@@ -1636,7 +1762,7 @@ class SpotiFLAC_API(
                 post_download_command=post_download_command,
                 log_level=current_log_level,
                 loop=loop_minutes,
-                post_download_hooks=[log_hook],
+                post_download_hooks=[log_hook, failed_hook],
                 max_concurrent_downloads=max_concurrent,
                 verify_hires=verify_hires,
                 redownload_fake_hires=redownload_fake_hires,
@@ -1652,7 +1778,12 @@ class SpotiFLAC_API(
                 # every 'active' row done, which with a second batch queued
                 # behind this one meant marking tracks finished before they
                 # had started.
-                self._push("app_download_finished", True, list(selected_indices))
+                if announce:
+                    self._push("app_download_finished", True, list(selected_indices))
+                else:
+                    self._push(
+                        "app_background_download_finished", True, len(selected_indices)
+                    )
             except Exception:
                 pass
 
@@ -1661,7 +1792,12 @@ class SpotiFLAC_API(
             self.set_progress("Error.")
             self._push_download_stats()
             try:
-                self._push("app_download_finished", False, list(selected_indices))
+                if announce:
+                    self._push("app_download_finished", False, list(selected_indices))
+                else:
+                    self._push(
+                        "app_background_download_finished", False, len(selected_indices)
+                    )
             except Exception:
                 pass
         finally:

--- a/SpotiFLAC/core/db.py
+++ b/SpotiFLAC/core/db.py
@@ -182,6 +182,49 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
         # for everyone or for one account.
         "CREATE INDEX IF NOT EXISTS idx_downloads_time ON downloads(downloaded_at)",
     ),
+    # v3 — one row per file, not one per run.
+    #
+    # The post-download hook used to record skipped tracks as well, so every
+    # re-run of a playlist appended a fresh successful row for each file that
+    # was already on disk, and the dashboard, quotas and totals counted the
+    # same file once per run. The hook no longer does that (see
+    # download_log.record_hook); this removes the duplicates it left behind.
+    # Each file keeps its earliest row — the one that says when it actually
+    # arrived. Failed attempts have no file and are left alone: they are
+    # attempts, and the dashboard reports them as such.
+    (
+        """
+        DELETE FROM downloads
+        WHERE success = 1 AND file_path != ''
+          AND id NOT IN (
+              SELECT MIN(id) FROM downloads
+              WHERE success = 1 AND file_path != ''
+              GROUP BY owner, file_path
+          )
+        """,
+    ),
+    # v4 — the tracks that still have to be downloaded.
+    #
+    # A run's failures lived only in the downloader's memory and in the
+    # frontend's queue, so a restart or a page reload lost the one list of
+    # what was still missing. core/failed_tracks.py keeps it here: one row
+    # per track per account, with the full metadata a retry needs after the
+    # tracklist it came from is gone, removed as soon as the track downloads.
+    (
+        """
+        CREATE TABLE IF NOT EXISTS failed_tracks (
+            owner           TEXT NOT NULL DEFAULT '',
+            track_key       TEXT NOT NULL,
+            track           TEXT NOT NULL,
+            source_url      TEXT NOT NULL DEFAULT '',
+            error           TEXT NOT NULL DEFAULT '',
+            attempts        INTEGER NOT NULL DEFAULT 1,
+            first_failed_at REAL NOT NULL,
+            last_failed_at  REAL NOT NULL,
+            PRIMARY KEY (owner, track_key)
+        )
+        """,
+    ),
 )
 
 

--- a/SpotiFLAC/core/db.py
+++ b/SpotiFLAC/core/db.py
@@ -225,6 +225,19 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
         )
         """,
     ),
+    # v5 — which queue a persisted job belongs to.
+    #
+    # Two JobQueues now share the jobs table: multi-user's, whose payloads are
+    # positions in an account's tracklist, and single-user --web's, whose
+    # payloads carry the tracks themselves (see webapp.py). A process
+    # restarted in the other mode restored the other queue's rows and handed
+    # them to a handler that cannot read them. Each queue now sees only its
+    # own kind. Every row written before this came from multi-user's queue,
+    # the only one that persisted.
+    (
+        "ALTER TABLE jobs ADD COLUMN kind TEXT NOT NULL DEFAULT ''",
+        "UPDATE jobs SET kind = 'multiuser'",
+    ),
 )
 
 

--- a/SpotiFLAC/core/download_log.py
+++ b/SpotiFLAC/core/download_log.py
@@ -182,6 +182,26 @@ def _file_size(path: str) -> int:
         return 0
 
 
+def _already_recorded(owner: str, file_path: str) -> bool:
+    """Whether `owner` already has a successful row for this exact file."""
+    if not file_path:
+        return False
+    try:
+        row = (
+            db.connection()
+            .execute(
+                "SELECT 1 FROM downloads "
+                "WHERE owner = ? AND file_path = ? AND success = 1 LIMIT 1",
+                (owner, file_path),
+            )
+            .fetchone()
+        )
+        return row is not None
+    except Exception:
+        logger.debug("[download_log] _already_recorded failed", exc_info=True)
+        return False
+
+
 def record_hook(owner: str = "") -> Any:
     """A post-download hook that writes each finished track to the log.
 
@@ -191,6 +211,17 @@ def record_hook(owner: str = "") -> Any:
     """
 
     def _on_track(result: Any, metadata: Any) -> None:
+        # A skip is not a download. Re-running a playlist reports every track
+        # already on disk as a skipped success, and recording each of those
+        # counted the same file once more per run: three runs of a playlist
+        # turned a 1,100-track library into 3,177 in the dashboard. The first
+        # skip of a file the log has never seen is still recorded, so a
+        # library that predates the log is learned once — has_isrc() and
+        # subscriptions rely on that.
+        if getattr(result, "skipped", False) and _already_recorded(
+            owner, getattr(result, "file_path", "") or ""
+        ):
+            return
         record(
             owner=owner,
             spotify_id=getattr(metadata, "id", "") or "",

--- a/SpotiFLAC/core/failed_tracks.py
+++ b/SpotiFLAC/core/failed_tracks.py
@@ -1,0 +1,230 @@
+"""core/failed_tracks.py — the tracks that still have to be downloaded.
+
+A run's failures used to live in two places, and neither outlived it: the
+downloader's own list (printed in the end-of-run summary, then dropped) and
+the frontend's queue (emptied by a page reload, and never filled at all for a
+download the browser did not start). A playlist of 1,800 tracks that ended
+with 40 failures therefore left no record of which 40 — the only way to find
+them again was to run the whole playlist.
+
+This is that record: one row per track per account, written by a
+post-download hook the moment a track fails and removed the moment it
+downloads — in the same run or any later one, including when a later run
+finds the file already on disk. What is left in the table is exactly what is
+still missing, which is what the queue panel's "Retry" re-submits.
+
+Each row keeps the track's full metadata, not only a link: a retry has to be
+able to run after a restart, when the tracklist the failure came from is no
+longer in memory.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+#: A provider error can run to a traceback; the panel shows one line of it.
+_MAX_ERROR_CHARS = 500
+
+
+def track_key(metadata: Any) -> str:
+    """What identifies one track across runs.
+
+    The source's own id first (the same track fetched from the same playlist
+    twice has the same id), then the ISRC, then title and artists — a CSV row
+    can carry nothing more. Empty when there is nothing to go on at all.
+    """
+    for attr in ("id", "isrc"):
+        value = str(getattr(metadata, attr, "") or "").strip()
+        if value:
+            return f"{attr}:{value}"
+    title = str(getattr(metadata, "title", "") or "").strip().lower()
+    if not title:
+        return ""
+    artists = str(getattr(metadata, "artists", "") or "").strip().lower()
+    return f"name:{title}|{artists}"
+
+
+def _serialise(metadata: Any) -> str:
+    dump = getattr(metadata, "model_dump", None)
+    if dump is None:
+        return ""
+    try:
+        return db.dumps(dump(mode="json"))
+    except Exception:
+        logger.debug("[failed_tracks] could not serialise a track", exc_info=True)
+        return ""
+
+
+def record_failure(
+    owner: str, metadata: Any, error: str = "", source_url: str = ""
+) -> None:
+    """Adds a failed track, or counts one more attempt at it. Never raises.
+
+    The same contract as download_log.record(): this runs from a
+    post-download hook, and bookkeeping must never turn into a failure of the
+    download it is keeping books on.
+    """
+    key = track_key(metadata)
+    track = _serialise(metadata)
+    if not key or not track:
+        return
+    now = time.time()
+    try:
+        with db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO failed_tracks (
+                    owner, track_key, track, source_url, error,
+                    attempts, first_failed_at, last_failed_at
+                ) VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+                ON CONFLICT(owner, track_key) DO UPDATE SET
+                    track          = excluded.track,
+                    source_url     = excluded.source_url,
+                    error          = excluded.error,
+                    attempts       = failed_tracks.attempts + 1,
+                    last_failed_at = excluded.last_failed_at
+                """,
+                (
+                    owner or "",
+                    key,
+                    track,
+                    source_url or "",
+                    (error or "")[:_MAX_ERROR_CHARS],
+                    now,
+                    now,
+                ),
+            )
+    except Exception:
+        logger.debug("[failed_tracks] could not record %s", key, exc_info=True)
+
+
+def resolve(owner: str, metadata: Any) -> None:
+    """Forgets a track that has now downloaded. Never raises."""
+    key = track_key(metadata)
+    if not key:
+        return
+    try:
+        with db.transaction() as conn:
+            conn.execute(
+                "DELETE FROM failed_tracks WHERE owner = ? AND track_key = ?",
+                (owner or "", key),
+            )
+    except Exception:
+        logger.debug("[failed_tracks] could not resolve %s", key, exc_info=True)
+
+
+def hook(owner: str = "", source_url: str = "") -> Callable[[Any, Any], None]:
+    """A post-download hook that keeps the table in step with each run.
+
+    A success resolves the track, and so does a skip — a skipped track is one
+    that is already on disk, which is the outcome a retry is after. Anything
+    else is recorded, with `source_url` kept so the retry can rebuild the
+    track's link (see core.tracklist.track_url).
+    """
+
+    def _on_track(result: Any, metadata: Any) -> None:
+        if getattr(result, "success", False):
+            resolve(owner, metadata)
+        else:
+            record_failure(
+                owner, metadata, getattr(result, "error", "") or "", source_url
+            )
+
+    _on_track.__qualname__ = "failed_tracks.hook.on_track"
+    return _on_track
+
+
+def _rows(owner: str, keys: Iterable[str] | None) -> list[Any]:
+    rows = (
+        db.connection()
+        .execute(
+            "SELECT * FROM failed_tracks WHERE owner = ? ORDER BY last_failed_at DESC",
+            (owner or "",),
+        )
+        .fetchall()
+    )
+    if keys is None:
+        return rows
+    # Filtered here rather than with an IN (...) built for the occasion: the
+    # list is one account's failures, small by construction.
+    wanted = {str(k) for k in keys}
+    return [row for row in rows if row["track_key"] in wanted]
+
+
+def list_for(owner: str = "") -> list[dict]:
+    """What the queue panel shows, newest failure first. Never raises."""
+    try:
+        rows = _rows(owner, None)
+    except Exception:
+        logger.debug("[failed_tracks] could not read the list", exc_info=True)
+        return []
+    items: list[dict] = []
+    for row in rows:
+        track = db.loads(row["track"], {}) or {}
+        items.append(
+            {
+                "key": row["track_key"],
+                "title": track.get("title", ""),
+                "artists": track.get("artists", ""),
+                "album": track.get("album", ""),
+                "error": row["error"],
+                "attempts": int(row["attempts"]),
+                "first_failed_at": float(row["first_failed_at"]),
+                "last_failed_at": float(row["last_failed_at"]),
+            }
+        )
+    return items
+
+
+def retry_groups(
+    owner: str = "", keys: Iterable[str] | None = None
+) -> list[tuple[str, list[dict]]]:
+    """The failures to re-submit, grouped by the collection they came from.
+
+    Grouped because a bare track id only turns into a link next to the
+    service that issued it, and one download job carries one source URL.
+    Never raises.
+    """
+    try:
+        rows = _rows(owner, keys)
+    except Exception:
+        logger.debug("[failed_tracks] could not read the list", exc_info=True)
+        return []
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        track = db.loads(row["track"], None)
+        if isinstance(track, dict):
+            groups.setdefault(row["source_url"] or "", []).append(track)
+    return list(groups.items())
+
+
+def clear(owner: str = "", keys: Iterable[str] | None = None) -> int:
+    """Drops failures from the list without retrying them.
+
+    All of the account's, or only `keys`. Returns how many rows went. Never
+    raises.
+    """
+    removed = 0
+    try:
+        with db.transaction() as conn:
+            if keys is None:
+                removed = conn.execute(
+                    "DELETE FROM failed_tracks WHERE owner = ?", (owner or "",)
+                ).rowcount
+            else:
+                for key in {str(k) for k in keys}:
+                    removed += conn.execute(
+                        "DELETE FROM failed_tracks WHERE owner = ? AND track_key = ?",
+                        (owner or "", key),
+                    ).rowcount
+    except Exception:
+        logger.debug("[failed_tracks] could not clear the list", exc_info=True)
+        return 0
+    return removed

--- a/SpotiFLAC/core/job_queue.py
+++ b/SpotiFLAC/core/job_queue.py
@@ -126,6 +126,7 @@ class JobQueue:
         max_pending_per_owner: int = DEFAULT_MAX_PENDING_PER_OWNER,
         persist: bool = False,
         quota_check: Callable[[str], None] | None = None,
+        kind: str = "",
     ) -> None:
         self._handler = handler
         self._queue: queue.Queue[str] = queue.Queue()
@@ -133,6 +134,11 @@ class JobQueue:
         self._max_history = max_history
         self._max_pending_per_owner = max_pending_per_owner
         self._persist = persist
+        # Which of the queues sharing the `jobs` table this one is. Restore,
+        # write and delete only ever touch rows of this kind: two queues'
+        # payloads are different shapes, and a process restarted in the other
+        # mode must not hand one queue's jobs to the other's handler.
+        self._kind = kind
         # Called with the owner just before a job is accepted; it raises to
         # refuse. Injected rather than imported so this module keeps knowing
         # nothing about accounts — see webapp.py, which passes the
@@ -174,7 +180,10 @@ class JobQueue:
         try:
             rows = (
                 db.connection()
-                .execute("SELECT * FROM jobs ORDER BY created_at")
+                .execute(
+                    "SELECT * FROM jobs WHERE kind = ? ORDER BY created_at",
+                    (self._kind,),
+                )
                 .fetchall()
             )
         except Exception:
@@ -223,8 +232,8 @@ class JobQueue:
                     """
                     INSERT INTO jobs (
                         id, owner, payload, status,
-                        created_at, started_at, finished_at, error
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        created_at, started_at, finished_at, error, kind
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(id) DO UPDATE SET
                         status      = excluded.status,
                         started_at  = excluded.started_at,
@@ -240,6 +249,7 @@ class JobQueue:
                         job.started_at,
                         job.finished_at,
                         job.error,
+                        self._kind,
                     ),
                 )
         except Exception:
@@ -259,7 +269,8 @@ class JobQueue:
         try:
             with db.transaction() as conn:
                 conn.executemany(
-                    "DELETE FROM jobs WHERE id = ?", [(i,) for i in job_ids]
+                    "DELETE FROM jobs WHERE id = ? AND kind = ?",
+                    [(i, self._kind) for i in job_ids],
                 )
         except Exception:
             logger.debug("[JobQueue] Could not evict persisted jobs", exc_info=True)

--- a/SpotiFLAC/frontend/app.js
+++ b/SpotiFLAC/frontend/app.js
@@ -1315,9 +1315,24 @@ window.app_download_finished = (success = true, indices = null) => {
   if (waiting.length > 0) {
     startDownloadQueue();
   }
+  loadFailedTracks();
+};
+// A download this page did not dispatch — a batch the backend resumed after a
+// restart, or a retry from the missing-tracks list — ends here instead of in
+// app_download_finished, which closes the oldest batch *this page* sent and
+// would close the wrong rows.
+window.app_background_download_finished = (success = true, count = 0) => {
+  loadFailedTracks();
+  logMessage(
+    success
+      ? `Background download finished (${count} track(s)).`
+      : 'Background download failed.',
+    success ? 'ok' : 'error',
+  );
 };
 window.loadHistoryAndProfiles = async () => {
   if (!window.pywebview?.api) return;
+  loadFailedTracks();
   try {
     const hist     = await window.pywebview.api.get_history();
     renderRecent(hist);
@@ -3698,6 +3713,88 @@ function toggleQueueDrawer() {
   const drawer = $('queue-drawer');
   if (!drawer) return;
   drawer.classList.toggle('open');
+  if (drawer.classList.contains('open')) loadFailedTracks();
+}
+
+// ── Tracks still missing ─────────────────────────────────────────────────
+// The backend's list (core/failed_tracks.py): every track that failed and has
+// not downloaded since, across runs and restarts. Unlike `queue`, it is not
+// this page's memory, so it is re-read rather than kept in step by hand.
+let failedTracks = [];
+
+async function loadFailedTracks() {
+  if (!window.pywebview?.api?.get_failed_tracks) return;
+  try {
+    const doc = await window.pywebview.api.get_failed_tracks();
+    failedTracks = Array.isArray(doc?.tracks) ? doc.tracks : [];
+  } catch (e) {
+    console.warn('[failed-tracks] could not load the list:', e);
+    return;
+  }
+  renderFailedTracks();
+}
+
+function renderFailedTracks() {
+  const panel = $('failed-panel');
+  if (!panel) return;
+  panel.classList.toggle('hidden', failedTracks.length === 0);
+  const count = $('fp-count');
+  if (count) count.textContent = String(failedTracks.length);
+  const title = $('fp-title');
+  if (title && title.lastChild) {
+    title.lastChild.textContent = failedTracks.length === 1
+      ? ' track still missing'
+      : ' tracks still missing';
+  }
+  const list = $('fp-list');
+  if (!list) return;
+  list.innerHTML = failedTracks.map((t) => {
+    const name = [t.title, t.artists].filter(Boolean).join(' — ') || t.key;
+    const tries = t.attempts > 1 ? `${t.attempts} tries` : '1 try';
+    const error = t.error || 'No error message';
+    return `
+      <li class="fp-item">
+        <div class="fp-main">
+          <div class="fp-name" title="${regEscapeHtml(name)}">${regEscapeHtml(name)}</div>
+          <div class="fp-error" title="${regEscapeHtml(error)}">${regEscapeHtml(error)}</div>
+        </div>
+        <span class="fp-attempts">${tries}</span>
+        <button type="button" class="act-btn secondary" data-key="${regEscapeHtml(t.key)}"
+          onclick="retryFailedTracks([this.dataset.key])">Retry</button>
+      </li>`;
+  }).join('');
+}
+
+function toggleFailedList() {
+  const list = $('fp-list');
+  if (!list) return;
+  const open = !list.classList.toggle('hidden');
+  const btn = $('fp-toggle');
+  if (btn) {
+    btn.textContent = open ? 'Hide' : 'Show';
+    btn.setAttribute('aria-expanded', String(open));
+  }
+}
+
+async function retryFailedTracks(keys = null) {
+  if (!window.pywebview?.api?.retry_failed_tracks) return;
+  try {
+    const res = await window.pywebview.api.retry_failed_tracks(buildConfig(), keys);
+    if (!res?.queued) showToast('Nothing left to retry.', 'info');
+  } catch (e) {
+    logMessage('Could not retry the missing tracks: ' + e, 'error');
+  }
+}
+
+async function clearFailedTracks() {
+  if (!window.pywebview?.api?.clear_failed_tracks) return;
+  try {
+    await window.pywebview.api.clear_failed_tracks(null);
+  } catch (e) {
+    logMessage('Could not clear the missing-tracks list: ' + e, 'error');
+    return;
+  }
+  loadFailedTracks();
 }
 
 // The four counters double as filters: the number and the way to see what it

--- a/SpotiFLAC/frontend/index.html
+++ b/SpotiFLAC/frontend/index.html
@@ -10,7 +10,7 @@
        tells itself apart from --web. Harmless to load in the desktop
        pywebview window too: manifest/theme-color are simply unused there,
        and the registration script below no-ops without that flag. -->
-  <link rel="manifest" href="manifest.json?v=20260921">
+  <link rel="manifest" href="manifest.json?v=20260922">
   <meta name="theme-color" content="#0a0a0c">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="SpotiFLAC">
@@ -21,7 +21,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/icons/logo.svg">
   <link rel="icon" type="image/png" sizes="192x192" href="assets/icons/logo-192.png">
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Syne:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css?v=20260921">
+  <link rel="stylesheet" href="styles.css?v=20260922">
   <script>
     // Theme, applied before the first paint. app.js used to do this only from
     // its 'pywebviewready' handler, which meant the window painted light and
@@ -1131,6 +1131,25 @@
             <button type="button" class="qs-item failed" onclick="filterQueue('error')" aria-pressed="false"><span class="qs-icon">✕</span><strong id="q-failed">0</strong>Failed</button>
           </div>
 
+          <!-- The backend's list of tracks that failed and have not downloaded
+               since (core/failed_tracks.py), kept across runs and restarts.
+               The counters above only know this page's own queue, which a
+               reload empties. Hidden while the list is empty. -->
+          <section id="failed-panel" class="failed-panel hidden" aria-labelledby="fp-title">
+            <div class="fp-head">
+              <div class="fp-text">
+                <strong id="fp-title"><span id="fp-count">0</span> tracks still missing</strong>
+                <span class="fp-sub">Kept until they download, even across restarts.</span>
+              </div>
+              <div class="fp-actions">
+                <button type="button" class="act-btn secondary" id="fp-toggle" onclick="toggleFailedList()" aria-expanded="false" aria-controls="fp-list">Show</button>
+                <button type="button" class="act-btn secondary" onclick="clearFailedTracks()">Clear list</button>
+                <button type="button" class="act-btn primary" id="fp-retry" onclick="retryFailedTracks()">Retry all</button>
+              </div>
+            </div>
+            <ul id="fp-list" class="fp-list hidden"></ul>
+          </section>
+
           <div class="queue-toolbar">
             <span class="ts-icon">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
@@ -1157,8 +1176,8 @@
           <div id="queue-counter"><span id="q-count">0 tracks</span><span id="q-done"></span></div>
         </div>
       </div>
-  <script src="toast-system.js?v=20260921"></script>
-  <script src="app.js?v=20260921"></script>
+  <script src="toast-system.js?v=20260922"></script>
+  <script src="app.js?v=20260922"></script>
   <script>
     // --web mode only (see sw.js's own comment for what the service worker
     // actually does — installability, not offline caching of live data).

--- a/SpotiFLAC/frontend/styles.css
+++ b/SpotiFLAC/frontend/styles.css
@@ -1988,6 +1988,38 @@
       font-size: var(--fs-200); color: var(--text2);
     }
     .queue-stats-bar strong { color: var(--text); font-family: var(--font-mono); }
+    /* Tracks still missing (see the #failed-panel comment in index.html).
+       Same surface and radius as the counters above it, so it reads as part
+       of the queue rather than as a warning banner dropped on top. */
+    .failed-panel {
+      margin: 0 24px var(--sp-4);
+      padding: 12px 14px;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      font-size: var(--fs-200); color: var(--text2);
+    }
+    .failed-panel .fp-head { display: flex; align-items: center; gap: var(--sp-4); flex-wrap: wrap; }
+    .failed-panel .fp-text { display: flex; flex-direction: column; gap: 2px; flex: 1; min-width: 160px; }
+    .failed-panel .fp-text strong { color: var(--status-failed-fg); font-weight: 700; }
+    .failed-panel .fp-sub { font-size: var(--fs-75); color: var(--muted); }
+    .failed-panel .fp-actions { display: flex; gap: var(--sp-3); flex-wrap: wrap; }
+    .failed-panel .act-btn { padding: 7px 12px; font-size: var(--fs-75); }
+    .fp-list {
+      list-style: none; margin: 10px 0 0; padding: 0;
+      max-height: 220px; overflow-y: auto;
+      display: flex; flex-direction: column; gap: 6px;
+    }
+    .fp-item {
+      display: flex; align-items: center; gap: var(--sp-3);
+      padding: 6px 8px; border-radius: var(--radius-sm);
+      border: 1px solid var(--border);
+    }
+    .fp-item .fp-main { flex: 1; min-width: 0; }
+    .fp-item .fp-name, .fp-item .fp-error { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .fp-item .fp-name { color: var(--text); }
+    .fp-item .fp-error { font-size: var(--fs-75); color: var(--muted); }
+    .fp-item .fp-attempts { font-size: var(--fs-75); color: var(--muted); font-family: var(--font-mono); white-space: nowrap; }
     .queue-summary .qs-icon {
       width: 34px; height: 34px; border-radius: var(--radius-md);
       display: grid; place-items: center; background: var(--status-active-bg);

--- a/SpotiFLAC/frontend/web-shim.js
+++ b/SpotiFLAC/frontend/web-shim.js
@@ -176,6 +176,7 @@
     'set_subscription_enabled', 'reset_subscription', 'check_subscriptions',
     'get_extension_health', 'reset_extension_health',
     'get_stats',
+    'get_failed_tracks', 'retry_failed_tracks', 'clear_failed_tracks',
     // CSV import sends the file's text, read in the browser — never a path.
     'preview_csv', 'fetch_csv',
   ];
@@ -304,6 +305,7 @@
   // checks the two agree; three names had already drifted out before it did.
   const ALLOWED_PUSH_FNS = new Set([
     '__set_version_label',
+    'app_background_download_finished',
     'app_cover_download_finished',
     'app_csv_error',
     'app_csv_loaded',

--- a/SpotiFLAC/webapp.py
+++ b/SpotiFLAC/webapp.py
@@ -501,6 +501,9 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
             # the one where a lost backlog is least likely to be noticed.
             persist=True,
             quota_check=_quota_check,
+            # Its own rows only: single-user --web persists into the same
+            # table (see below), with payloads this handler cannot read.
+            kind="multiuser",
         )
 
     # Single-user --web runs its downloads through a persisted queue as well,
@@ -516,7 +519,12 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
     if not multiuser:
         from .core.job_queue import JobQueue
 
-        download_queue = JobQueue(handler=api.run_download_job, workers=1, persist=True)
+        download_queue = JobQueue(
+            handler=api.run_download_job,
+            workers=1,
+            persist=True,
+            kind="single-user",
+        )
         api._download_queue = download_queue
 
     @asynccontextmanager

--- a/SpotiFLAC/webapp.py
+++ b/SpotiFLAC/webapp.py
@@ -205,6 +205,11 @@ ALLOWED_METHODS: set[str] = {
     # the calling account's own history: each account gets its own Api
     # instance, and `owner` is set on it above.
     "get_stats",
+    # The tracks still missing after a download (see core/failed_tracks.py).
+    # Retrying is a download like any other; clearing only edits the list.
+    "get_failed_tracks",
+    "retry_failed_tracks",
+    "clear_failed_tracks",
     # CSV input (core/csv_source.py). Both take the file's *contents*, never
     # a path — the browser reads the file locally, so nothing here can be
     # pointed at a path on the host.
@@ -498,6 +503,22 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
             quota_check=_quota_check,
         )
 
+    # Single-user --web runs its downloads through a persisted queue as well,
+    # and for the reason multi-user's exists: this is the headless deployment,
+    # restarted by container updates and reboots nobody is watching. Each
+    # batch is written down before it starts — the tracks themselves, not
+    # positions in a tracklist that lives only in memory — and whatever a
+    # restart cut short is put back and runs again, skipping what is already
+    # on disk (see SpotiFLAC_API.download_tracks). Kept apart from
+    # `job_queue`: that is multi-user's account-aware queue, and /api/metrics
+    # and the v1 API read its presence as "multi-user".
+    download_queue = None
+    if not multiuser:
+        from .core.job_queue import JobQueue
+
+        download_queue = JobQueue(handler=api.run_download_job, workers=1, persist=True)
+        api._download_queue = download_queue
+
     @asynccontextmanager
     async def _lifespan(_app: FastAPI):
         manager.bind_loop(asyncio.get_running_loop())
@@ -530,6 +551,22 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
             await run_in_threadpool(api.log, f"Extension init error: {e}", "warn")
         api._push("loadHistoryAndProfiles")
         api._push("__set_version_label", api.app_version)
+        if download_queue is not None:
+            # Nothing has been submitted yet at this point, so anything queued
+            # or running is what the queue restored from the last process.
+            waiting = [
+                job
+                for job in download_queue.list_all()
+                if job.status.value in ("queued", "running")
+            ]
+            if waiting:
+                tracks = sum(len(job.payload.get("tracks") or []) for job in waiting)
+                await run_in_threadpool(
+                    api.log,
+                    f"Resuming {len(waiting)} download(s) ({tracks} track(s)) cut "
+                    "short by the last restart; tracks already on disk are skipped.",
+                    "info",
+                )
         yield
         # No shutdown-side work (yet) — everything here is process-lifetime
         # state (threads, in-memory sessions/queue) that dies with the
@@ -539,6 +576,7 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
     app.state.shared_api = app_state_api
     app.state.api_registry = registry
     app.state.job_queue = job_queue
+    app.state.download_queue = download_queue
 
     @app.middleware("http")
     async def _no_cache_frontend(request, call_next):
@@ -1064,11 +1102,11 @@ def create_app(token: str | None = None, multiuser: bool = False) -> FastAPI:
         html = (FRONTEND_DIR / "index.html").read_text(encoding="utf-8")
         inject = (
             "<script>window.__SPOTIFLAC_WEB_MODE__ = true;</script>\n"
-            '<script src="/web-shim.js?v=20260921"></script>\n'
+            '<script src="/web-shim.js?v=20260922"></script>\n'
         )
         html = html.replace(
-            '<script src="toast-system.js?v=20260921"></script>',
-            inject + '<script src="toast-system.js?v=20260921"></script>',
+            '<script src="toast-system.js?v=20260922"></script>',
+            inject + '<script src="toast-system.js?v=20260922"></script>',
         )
         # Marks the document as browser-served before the first paint, so CSS
         # can drop the chrome that only makes sense in the pywebview window

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "4.1.0"
+version = "4.1.2"
 description = "Fetch Spotify track metadata and retrieve matching lossless audio through configurable Tidal, Qobuz & Amazon Music provider backends."
 readme = "README.md"
 # 3.10, not 3.9: core/models.py declares PEP 604 unions (`str | None`) on

--- a/tests/test_db_persistence.py
+++ b/tests/test_db_persistence.py
@@ -178,6 +178,90 @@ def test_failed_downloads_do_not_count_towards_usage():
     assert download_log.count_since("alice", 0) == 0
 
 
+def _track(isrc: str) -> TrackMetadata:
+    return TrackMetadata(
+        id="sp-" + isrc,
+        title="Song",
+        artists="Artist",
+        album="Album",
+        album_artist="Artist",
+        isrc=isrc,
+    )
+
+
+def test_rerunning_a_playlist_does_not_count_a_file_twice(tmp_path):
+    from SpotiFLAC.core.models import DownloadResult
+
+    target = tmp_path / "song.m4a"
+    target.write_bytes(b"z" * 100)
+    hook = download_log.record_hook(owner="carol")
+
+    hook(DownloadResult.ok("ext:tidal-web", str(target)), _track("ITAAA0000009"))
+    # Two later runs find the file already on disk and skip it.
+    for _ in range(2):
+        hook(
+            DownloadResult.skipped_result("tidal", str(target)), _track("ITAAA0000009")
+        )
+
+    assert download_log.count_since("carol", 0) == 1
+    assert download_log.totals("carol") == {"tracks": 1, "bytes": 100}
+
+
+def test_first_skip_of_an_unrecorded_file_is_still_learned(tmp_path):
+    from SpotiFLAC.core.models import DownloadResult
+
+    # A file that was on disk before the log existed: its first skip is the
+    # only chance to learn it, and has_isrc() depends on that.
+    target = tmp_path / "old.m4a"
+    target.write_bytes(b"o" * 50)
+    hook = download_log.record_hook(owner="dave")
+
+    for _ in range(3):
+        hook(
+            DownloadResult.skipped_result("tidal", str(target)), _track("ITAAA0000010")
+        )
+
+    assert download_log.has_isrc("ITAAA0000010", owner="dave") is True
+    assert download_log.count_since("dave", 0) == 1
+
+
+def test_dedup_migration_keeps_one_row_per_file():
+    for _ in range(3):
+        download_log.record(owner="erin", file_path="/music/a.m4a", size_bytes=10)
+    download_log.record(owner="erin", file_path="/music/b.m4a", size_bytes=20)
+    # Another account's copy of the same path is its own file.
+    download_log.record(owner="frank", file_path="/music/a.m4a", size_bytes=10)
+    # Failed attempts have no file and must survive: they are attempts.
+    download_log.record(owner="erin", success=False)
+    download_log.record(owner="erin", success=False)
+
+    conn = db.connection()
+    first = conn.execute(
+        "SELECT MIN(id) FROM downloads WHERE owner = 'erin' AND file_path = '/music/a.m4a'"
+    ).fetchone()[0]
+
+    # Replay the migration the way an instance upgrading from v2 runs it.
+    dedup = next(
+        stmts
+        for stmts in db._MIGRATIONS
+        if any("DELETE FROM downloads" in s for s in stmts)
+    )
+    with conn:
+        for statement in dedup:
+            conn.execute(statement)
+
+    assert download_log.totals("erin") == {"tracks": 2, "bytes": 30}
+    assert download_log.totals("frank") == {"tracks": 1, "bytes": 10}
+    kept = conn.execute(
+        "SELECT id FROM downloads WHERE owner = 'erin' AND file_path = '/music/a.m4a'"
+    ).fetchall()
+    assert [r[0] for r in kept] == [first]
+    failed = conn.execute(
+        "SELECT COUNT(*) FROM downloads WHERE owner = 'erin' AND success = 0"
+    ).fetchone()[0]
+    assert failed == 2
+
+
 # ── History ───────────────────────────────────────────────────────────────
 
 

--- a/tests/test_db_persistence.py
+++ b/tests/test_db_persistence.py
@@ -88,6 +88,60 @@ def test_unfinished_jobs_are_restored_and_rerun():
     assert q.get("j-running").started_at is not None
 
 
+@pytest.mark.parametrize(
+    ("kind", "expected", "untouched"),
+    [("single-user", "s", "m1"), ("multiuser", "m", "s1")],
+)
+def test_a_queue_restores_only_its_own_kind_of_job(kind, expected, untouched):
+    """A process restarted in the other mode must not run the other queue's jobs.
+
+    Single-user --web and multi-user persist into the same table with payloads
+    of different shapes, and each handler can only read its own.
+    """
+    with db.transaction() as conn:
+        conn.executemany(
+            "INSERT INTO jobs (id, owner, payload, status, created_at, kind) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("m1", "alice", db.dumps({"n": "m"}), "running", 1.0, "multiuser"),
+                ("s1", "", db.dumps({"n": "s"}), "queued", 2.0, "single-user"),
+            ],
+        )
+
+    seen: list[str] = []
+    q = JobQueue(handler=lambda p: seen.append(p["n"]), persist=True, kind=kind)
+
+    _wait_until(lambda: seen == [expected])
+    assert q.get(untouched) is None
+    row = (
+        db.connection()
+        .execute("SELECT status FROM jobs WHERE id = ?", (untouched,))
+        .fetchone()
+    )
+    assert row["status"] in ("running", "queued"), "left for its own queue"
+
+
+def test_jobs_from_before_queue_kinds_stay_multi_users():
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO jobs (id, owner, payload, status, created_at, kind) "
+            "VALUES ('old', 'alice', ?, 'queued', 1.0, '')",
+            (db.dumps({"n": 1}),),
+        )
+        # The backfill an upgrade runs once, on a database that predates kinds.
+        backfill = next(
+            statement
+            for statements in db._MIGRATIONS
+            for statement in statements
+            if statement.startswith("UPDATE jobs SET kind")
+        )
+        conn.execute(backfill)
+
+    seen: list[int] = []
+    JobQueue(handler=lambda p: seen.append(p["n"]), persist=True, kind="multiuser")
+    _wait_until(lambda: seen == [1])
+
+
 def test_persistence_is_off_by_default():
     q = JobQueue(handler=lambda _payload: None)
     job = q.submit("alice", {})

--- a/tests/test_failed_tracks_and_resume.py
+++ b/tests/test_failed_tracks_and_resume.py
@@ -1,0 +1,243 @@
+"""Failed tracks outlive the run, and a --web download outlives a restart.
+
+Before, a download started from the web UI lived in a bare thread: a
+container update halfway through a 1,800-track playlist lost the batch, and
+nothing remembered which tracks had failed — the only way to find them again
+was to run the whole playlist. These tests pin the two halves of the fix: a
+download job carries its own tracks (not positions in a tracklist that is
+gone after a restart), and failures stay listed until they download.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import SpotiFLAC as spotiflac_pkg
+from SpotiFLAC.app import SpotiFLAC_API
+from SpotiFLAC.core import db, failed_tracks
+from SpotiFLAC.core.models import DownloadResult, TrackMetadata
+
+PLAYLIST = "https://open.spotify.com/playlist/p"
+
+
+def _track(n: int) -> TrackMetadata:
+    return TrackMetadata(
+        id=f"sp{n}",
+        title=f"Song {n}",
+        artists="Artist",
+        album="Album",
+        album_artist="Artist",
+        isrc=f"ITAAA000000{n}",
+        external_url=f"https://open.spotify.com/track/sp{n}",
+    )
+
+
+class _RecordingQueue:
+    """Stands in for the persisted JobQueue: keeps what was submitted."""
+
+    def __init__(self) -> None:
+        self.jobs: list[tuple[str, dict]] = []
+
+    def submit(self, owner: str, payload: dict) -> None:
+        self.jobs.append((owner, payload))
+
+
+@pytest.fixture()
+def calls(monkeypatch):
+    seen: list[dict] = []
+    monkeypatch.setattr(spotiflac_pkg, "SpotiFLAC", lambda **kw: seen.append(kw))
+    return seen
+
+
+def _api(tmp_path, tracks: int = 3) -> SpotiFLAC_API:
+    api = SpotiFLAC_API()
+    api.download_dir = str(tmp_path)
+    api.current_tracks = [_track(n) for n in range(tracks)]
+    api.current_url = PLAYLIST
+    return api
+
+
+# ── core/failed_tracks.py ─────────────────────────────────────────────────
+
+
+def test_a_failure_is_listed_and_a_later_success_clears_it(tmp_path):
+    hook = failed_tracks.hook(source_url=PLAYLIST)
+    hook(DownloadResult.fail("tidal", "no stream"), _track(1))
+    hook(DownloadResult.fail("qobuz", "not found"), _track(1))
+
+    [item] = failed_tracks.list_for()
+    assert item["title"] == "Song 1"
+    assert item["attempts"] == 2
+    assert item["error"] == "not found"
+
+    target = tmp_path / "song.m4a"
+    target.write_bytes(b"x")
+    hook(DownloadResult.ok("tidal", str(target)), _track(1))
+    assert failed_tracks.list_for() == []
+
+
+def test_a_skip_means_the_track_is_there(tmp_path):
+    hook = failed_tracks.hook()
+    hook(DownloadResult.fail("tidal", "boom"), _track(2))
+    hook(DownloadResult.skipped_result("tidal", str(tmp_path / "x.m4a")), _track(2))
+    assert failed_tracks.list_for() == []
+
+
+def test_each_account_has_its_own_list():
+    failed_tracks.hook(owner="alice")(DownloadResult.fail("t", "e"), _track(3))
+    assert len(failed_tracks.list_for("alice")) == 1
+    assert failed_tracks.list_for("bob") == []
+
+
+def test_retry_groups_keep_the_source_and_clear_takes_keys():
+    failed_tracks.hook(source_url=PLAYLIST)(DownloadResult.fail("t", "e"), _track(4))
+    tidal = "https://tidal.com/browse/playlist/b"
+    failed_tracks.hook(source_url=tidal)(DownloadResult.fail("t", "e"), _track(5))
+
+    groups = dict(failed_tracks.retry_groups())
+    assert set(groups) == {PLAYLIST, tidal}
+    assert groups[PLAYLIST][0]["id"] == "sp4"
+
+    assert failed_tracks.clear(keys=[failed_tracks.track_key(_track(4))]) == 1
+    assert [i["key"] for i in failed_tracks.list_for()] == [
+        failed_tracks.track_key(_track(5))
+    ]
+    assert failed_tracks.clear() == 1
+
+
+# ── Persisted download jobs ───────────────────────────────────────────────
+
+
+def test_a_web_download_is_written_down_as_tracks_not_positions(tmp_path, calls):
+    api = _api(tmp_path)
+    api._download_queue = _RecordingQueue()
+
+    api.download_tracks([0, 2], {"services": ["tidal"]})
+
+    [(_, payload)] = api._download_queue.jobs
+    assert calls == [], "nothing runs until the queue picks the job up"
+    assert payload["indices"] == [0, 2]
+    assert [t["id"] for t in payload["tracks"]] == ["sp0", "sp2"]
+    assert payload["whole"] is False
+    assert payload["source_url"] == PLAYLIST
+
+
+def test_a_job_resumes_after_a_restart_without_the_tracklist(tmp_path, calls):
+    before = _api(tmp_path)
+    before._download_queue = _RecordingQueue()
+    before.download_tracks([0, 2], {"services": ["tidal"]})
+    # Exactly what the jobs table hands back to the next process.
+    payload = db.loads(db.dumps(before._download_queue.jobs[0][1]))
+
+    after = SpotiFLAC_API()  # empty tracklist, new session
+    after.download_dir = str(tmp_path)
+    pushed: list[tuple[str, tuple]] = []
+    after._push = lambda name, *args: pushed.append((name, args))
+    after.run_download_job(payload)
+
+    [call] = calls
+    assert call["url"] == [
+        "https://open.spotify.com/track/sp0",
+        "https://open.spotify.com/track/sp2",
+    ]
+    assert set(call["prefetched_tracks"]) == set(call["url"])
+    names = [name for name, _ in pushed]
+    assert "app_background_download_finished" in names
+    assert (
+        "app_download_finished" not in names
+    ), "a restored job must not close a batch the new page dispatched"
+
+
+def test_a_whole_playlist_resumes_as_the_playlist(tmp_path, calls):
+    api = _api(tmp_path)
+    api._download_queue = _RecordingQueue()
+    api.download_tracks([0, 1, 2], {"services": ["tidal"]})
+    payload = api._download_queue.jobs[0][1]
+    assert payload["whole"] is True
+
+    fresh = SpotiFLAC_API()
+    fresh.download_dir = str(tmp_path)
+    fresh.run_download_job(payload)
+    assert calls[-1]["url"] == PLAYLIST
+
+
+def test_this_sessions_job_still_closes_its_own_batch(tmp_path, calls):
+    api = _api(tmp_path)
+    api._download_queue = _RecordingQueue()
+    api.download_tracks([1], {"services": ["tidal"]})
+    pushed: list[tuple[str, tuple]] = []
+    api._push = lambda name, *args: pushed.append((name, args))
+
+    api.run_download_job(api._download_queue.jobs[0][1])
+
+    assert ("app_download_finished", (True, [1])) in pushed
+
+
+def test_the_desktop_window_still_downloads_straight_away(tmp_path, calls):
+    api = _api(tmp_path)  # no queue: what the desktop build gets
+    api.download_tracks([0], {"services": ["tidal"]})
+    deadline = time.time() + 3
+    while not calls and time.time() < deadline:
+        time.sleep(0.01)
+    assert calls, "without a queue the batch runs as it always has"
+
+
+def test_a_batchs_failures_are_listed_with_their_source(tmp_path, monkeypatch):
+    def _fake_download(**kw):
+        for hook in kw["post_download_hooks"]:
+            hook(DownloadResult.fail("tidal", "no stream"), _track(1))
+
+    monkeypatch.setattr(spotiflac_pkg, "SpotiFLAC", _fake_download)
+    _api(tmp_path)._download_task([1], {"services": ["tidal"]})
+
+    [item] = failed_tracks.list_for()
+    assert item["title"] == "Song 1"
+    [(source, _)] = failed_tracks.retry_groups()
+    assert source == PLAYLIST
+
+
+def test_retry_submits_the_missing_tracks_as_a_background_job():
+    failed_tracks.hook(source_url=PLAYLIST)(DownloadResult.fail("t", "e"), _track(7))
+    api = SpotiFLAC_API()
+    api._download_queue = _RecordingQueue()
+
+    assert api.retry_failed_tracks({"services": ["tidal"]}) == {"queued": 1}
+
+    [(_, payload)] = api._download_queue.jobs
+    assert payload["whole"] is False
+    assert payload["tracks"][0]["id"] == "sp7"
+    assert "session" not in payload, "no open page dispatched a retry"
+    # Still listed: only an actual download takes a track off the list.
+    assert len(api.get_failed_tracks()["tracks"]) == 1
+
+
+# ── webapp.py wiring ──────────────────────────────────────────────────────
+
+
+def test_single_user_web_resumes_a_job_the_last_process_left(monkeypatch):
+    pytest.importorskip("fastapi")
+    from SpotiFLAC import webapp
+
+    ran: list[dict] = []
+    monkeypatch.setattr(
+        SpotiFLAC_API, "run_download_job", lambda self, payload: ran.append(payload)
+    )
+    # What the previous process left behind: a job that was running when it
+    # died.
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO jobs (id, owner, payload, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("j1", "", db.dumps({"indices": [], "session": "old"}), "running", 1.0),
+        )
+
+    app = webapp.create_app(token=None)
+
+    assert app.state.download_queue is not None
+    assert app.state.job_queue is None, "single-user must not look multi-user"
+    deadline = time.time() + 3
+    while not ran and time.time() < deadline:
+        time.sleep(0.01)
+    assert ran and ran[0]["session"] == "old"

--- a/tests/test_failed_tracks_and_resume.py
+++ b/tests/test_failed_tracks_and_resume.py
@@ -224,13 +224,18 @@ def test_single_user_web_resumes_a_job_the_last_process_left(monkeypatch):
     monkeypatch.setattr(
         SpotiFLAC_API, "run_download_job", lambda self, payload: ran.append(payload)
     )
-    # What the previous process left behind: a job that was running when it
-    # died.
+    # What the previous process left behind: its own job, running when it
+    # died, next to one a multi-user run left in the same table.
+    single = db.dumps({"indices": [], "session": "old"})
+    multi = db.dumps({"owner": "alice", "selected_indices": [0]})
     with db.transaction() as conn:
-        conn.execute(
-            "INSERT INTO jobs (id, owner, payload, status, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ("j1", "", db.dumps({"indices": [], "session": "old"}), "running", 1.0),
+        conn.executemany(
+            "INSERT INTO jobs (id, owner, payload, status, created_at, kind) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("j1", "", single, "running", 1.0, "single-user"),
+                ("m1", "alice", multi, "queued", 2.0, "multiuser"),
+            ],
         )
 
     app = webapp.create_app(token=None)
@@ -240,4 +245,24 @@ def test_single_user_web_resumes_a_job_the_last_process_left(monkeypatch):
     deadline = time.time() + 3
     while not ran and time.time() < deadline:
         time.sleep(0.01)
-    assert ran and ran[0]["session"] == "old"
+    assert [payload.get("session") for payload in ran] == ["old"]
+    assert app.state.download_queue.get("m1") is None, "not this queue's job"
+
+
+def test_multi_user_web_leaves_single_user_jobs_alone():
+    pytest.importorskip("fastapi")
+    from SpotiFLAC import webapp
+
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO jobs (id, owner, payload, status, created_at, kind) "
+            "VALUES ('j1', '', ?, 'running', 1.0, 'single-user')",
+            (db.dumps({"indices": [0], "tracks": [{}], "session": "old"}),),
+        )
+
+    app = webapp.create_app(token=None, multiuser=True)
+
+    assert app.state.download_queue is None
+    assert app.state.job_queue.get("j1") is None
+    row = db.connection().execute("SELECT status FROM jobs WHERE id = 'j1'").fetchone()
+    assert row["status"] == "running", "left for single-user mode to resume"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a persistent “Failed Tracks” panel to the download queue.
  - View failure details and attempt counts, retry selected or all tracks, or clear the list.
  - Web downloads now persist across restarts and resume automatically.
  - Background download completion updates are reflected in the interface.

- **Bug Fixes**
  - Prevented duplicate download-history entries for already recorded files.
  - Improved download failure tracking and recovery across sessions.

- **Chores**
  - Updated the application version to 4.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->