### PR TITLE
Always persist manifest.json with checksum and runtime hints

### DIFF
--- a/SpotiFLAC/extensions/manager.py
+++ b/SpotiFLAC/extensions/manager.py
@@ -683,7 +683,7 @@ class ExtensionManager:
         manifest = dict(manifest)
         manifest.pop("_registry_sha256", None)
         if sha256:
-            manifest["_registry_sha256"] = sha256.lower()
+            manifest["_registry_sha256"] = actual
 
         if runtime_hint == "python" and python_modules:
             manifest = dict(manifest)
@@ -754,10 +754,10 @@ class ExtensionManager:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 destination.write_bytes(zf.read(member))
 
-            if is_legacy_python:
-                (staging / "manifest.json").write_text(
-                    json.dumps(manifest, indent=2), encoding="utf-8"
-                )
+            # Persist checksum metadata and runtime hints for every package.
+            (staging / "manifest.json").write_text(
+                json.dumps(manifest, indent=2), encoding="utf-8"
+            )
             if saved_settings and not settings:
                 (staging / "settings.json").write_bytes(saved_settings)
             if settings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SpotiFLAC"
-version = "4.1.5"
+version = "4.1.6"
 description = "Fetch Spotify track metadata and retrieve matching lossless audio through configurable Tidal, Qobuz & Amazon Music provider backends."
 readme = "README.md"
 # 3.10, not 3.9: core/models.py declares PEP 604 unions (`str | None`) on


### PR DESCRIPTION
Otherwise, extensions are redownloaded on every run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Package installations now record the archive’s verified checksum instead of the registry’s expected value.
  - Installation metadata is now consistently saved for all package types, including runtime hints and checksum details.
- **Release**
  - Updated the application version to 4.1.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->